### PR TITLE
Make external links open in a new tab

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,14 +36,19 @@ nav_external_links:
 
   - title: Campuswire
     url: https://campuswire.com/c/GFBA7A8E4
+    opens_in_new_tab: true
   - title: Gradescope
     url: https://www.gradescope.com/courses/869551
+    opens_in_new_tab: true
   - title: Lecture Slides
     url: https://drive.google.com/drive/folders/1LoYIavpZMdKk3W_3YUzzYfrR6if4EtqM
+    opens_in_new_tab: true
   - title: Discussion Resources
     url: https://drive.google.com/drive/folders/1C36JJOtbb7dBU1hYbPuisS8m7dH6W4ff?usp=sharing
+    opens_in_new_tab: true
   - title: Barista
     url: https://barista-f23.fly.dev
+    opens_in_new_tab: true
 
 # Collections for website data
 collections:


### PR DESCRIPTION
Sorry this bugged me lol.

Please test this first. I don't feel like installing Ruby just for this, but I found [this](https://just-the-docs.com/docs/navigation/main/external/#opening-external-links-in-a-new-tab) in the docs, so I assume it should work.

Note: You could also just suppress the symbol with `hide_icon: true` instead. IMO think at least one of them should be set because it's kinda misleading. I prefer having them open in a new tab.